### PR TITLE
Fix cancelled continuation handling in Prefetch

### DIFF
--- a/async-enumerable-dotnet-test/PrefetchTest.cs
+++ b/async-enumerable-dotnet-test/PrefetchTest.cs
@@ -3,6 +3,8 @@
 // See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using async_enumerable_dotnet;
 
@@ -68,6 +70,14 @@ namespace async_enumerable_dotnet_test
                 .Prefetch(128)
                 .Take(1)
                 .AssertResult(1L);
+        }
+
+        [Fact]
+        public async void Cancel()
+        {
+            await AsyncEnumerable.FromTask(Task.FromCanceled<int>(new CancellationToken(true)))
+                .Prefetch(1)
+                .AssertFailure(typeof(OperationCanceledException));
         }
     }
 }

--- a/async-enumerable-dotnet/impl/Prefetch.cs
+++ b/async-enumerable-dotnet/impl/Prefetch.cs
@@ -93,6 +93,11 @@ namespace async_enumerable_dotnet.impl
                     _error = ExceptionHelper.Extract(t.Exception);
                     _done = true;
                 }
+                else if (t.IsCanceled)
+                {
+                    _error = new OperationCanceledException();
+                    _done = true;
+                }
                 else if (t.Result)
                 {
                     _queue.Enqueue(_source.Current);


### PR DESCRIPTION
Fix the handling of cancelled continuations within `Prefetch`.

Related: #8